### PR TITLE
Add legal conversation prompt

### DIFF
--- a/generation/core_pipelines/rptoolkit/config.yaml
+++ b/generation/core_pipelines/rptoolkit/config.yaml
@@ -13,7 +13,7 @@ path:
   default_prompts: ./prompts
   input_dir: ./inputs/!!PLACEHOLDER!!
   output_dir: ./outputs/!!PLACEHOLDER!!
-  prompts: ./prompts # !!ATTENTION!! by default uses normal prompts. "Spicy" prompts only compatible with the custom datagen model due to the need for vague prompts due to reputational risk.
+  prompts: ./prompt_overrides/legal_conversation # Use a legal conversation prompt override for attorney discussions.
 phases:
   phase_index: 2
   work_in_phases: True

--- a/generation/core_pipelines/rptoolkit/prompt_overrides/legal_conversation/case_assessment.yaml
+++ b/generation/core_pipelines/rptoolkit/prompt_overrides/legal_conversation/case_assessment.yaml
@@ -1,0 +1,8 @@
+- role: system
+  content: |
+    You are two seasoned attorneys tasked with evaluating a hypothetical legal scenario.
+    Discuss potential claims, defenses, and likely outcomes. Conclude with a concise joint assessment.
+    Present the discussion in Markdown and keep the tone professional.
+- role: user
+  content: |
+    {hypothetical}

--- a/generation/core_pipelines/rptoolkit/prompt_overrides/legal_conversation/hypothetical_generation.yaml
+++ b/generation/core_pipelines/rptoolkit/prompt_overrides/legal_conversation/hypothetical_generation.yaml
@@ -1,0 +1,7 @@
+- role: system
+  content: |
+    You are a legal analyst. Given a text excerpt describing a legal issue, craft a brief hypothetical scenario that illustrates the key facts and dispute.
+    Keep it professional and neutral. Write in Markdown format.
+- role: user
+  content: |
+    {text}

--- a/generation/core_pipelines/rptoolkit/prompt_overrides/legal_conversation/multi_turn_attorney_conversation.yaml
+++ b/generation/core_pipelines/rptoolkit/prompt_overrides/legal_conversation/multi_turn_attorney_conversation.yaml
@@ -1,0 +1,15 @@
+- role: system
+  content: |
+    You are drafting a professional dialogue between two experienced attorneys. The discussion is based on a provided text excerpt.
+    The attorneys should use the excerpt to craft a hypothetical scenario and then collaboratively assess potential claims, defenses and likely outcomes.
+    The conversation must flow naturally over multiple turns, with each attorney asking clarifying questions and offering analysis.
+    Write in Markdown format. Keep the tone professional and concise.
+
+    **Conversation guidelines:**
+      * Start with Attorney A posing an initial question about the text.
+      * Attorney B responds with analysis, then poses a follow‑up question.
+      * Continue for several exchanges, weaving in the hypothetical case based on the text.
+      * Conclude with both attorneys summarizing their assessment of the hypothetical case.
+- role: user
+  content: |
+    {text}


### PR DESCRIPTION
## Summary
- add new prompt override `multi_turn_attorney_conversation.yaml`
- use this prompt override in `rptoolkit` pipeline config
- add standalone prompts for generating a hypothetical scenario and a case assessment

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68519d560588832bb0dd1a1f14892879